### PR TITLE
chore: bump alpine base to 3.24.1 and track Docker in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19.1
+FROM alpine:3.24.1
 
 RUN apk --no-cache add \
         python3 \


### PR DESCRIPTION
Resolves maintenance followup ticket #52.

## Problem

`.github/dependabot.yml` only configured the `github-actions` ecosystem, so the Dockerfile's `FROM alpine:3.19.1` pin never received update PRs and had drifted well behind current releases. Since `python3`/`py3-pip`/`s3cmd` are installed unpinned from apk, the base image is also the main lever on those versions.

## Changes

- Add a `docker` ecosystem block to `.github/dependabot.yml` (weekly) so base-image updates get PRs going forward.
- Bump `FROM alpine:3.19.1` → `alpine:3.24.1` (current latest).

## Verification

Built locally and exercised against a MinIO server in a Docker network:

- Image builds clean; `s3cmd --version` reports 2.4.0.
- `SYNC_MODE=STARTUP` uploads local → `s3://` successfully.
- `SYNC_MODE=STARTUP` downloads `s3://` → local, honoring `COMPLETION_FILENAME` (touch + `--exclude`) and `CHMOD_MODE`.
- `SYNC_MODE=PERIODIC` writes the crontab and `crond` fires the sync on schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)