### PR TITLE
ci: validate the image build on pull requests

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,0 +1,33 @@
+---
+name: PR Build
+
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-buildx-action@v4
+    - uses: actions/checkout@v7
+    # Build only, never push. The `RUN s3cmd --version` line in the Dockerfile
+    # acts as the smoke test: a base image bump that drops or renames an apk
+    # package fails here instead of on master. Single-platform to keep PR
+    # builds fast; the multi-arch build still happens on push to master.
+    - uses: docker/build-push-action@v7
+      with:
+        context: .
+        push: false
+        platforms: linux/amd64
+        tags: periodic-s3-sync:pr-${{ github.event.pull_request.number }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem

No workflow in this repo has a `pull_request` trigger — `build-and-push.yaml` is `push` to `master` only, and `ghcr-lifecycle.yaml` is `schedule` + `workflow_dispatch`. So **no PR ever gets a status check**.

Since essentially every change here is an alpine base-image bump or a GitHub Actions bump, the first time a bad bump gets exercised is after it lands on `master` — where the same workflow has already been asked to push `ghcr.io/zostay/periodic-s3-sync:latest`. A failure leaves `master` red with no fresh `latest` and requires a roll-forward.

It also breaks Dependabot sweep tooling, which reads PR checks to decide readiness: a PR with zero checks looks the same as a validated one.

## Change

New `.github/workflows/pr-build.yaml`:

- `pull_request` → `master`, build-only (`push: false`), so nothing reaches the registry.
- `linux/amd64` only. Native build, no QEMU, fast turnaround; the multi-arch build stays on the push-to-master workflow.
- The existing `RUN s3cmd --version` line in the Dockerfile is the smoke test — an alpine bump that drops or renames `python3`/`py3-pip`/`s3cmd` now fails on the PR instead of on `master`.
- `permissions: contents: read`, `concurrency` with `cancel-in-progress`, and GHA layer cache shared across runs.

## Verification

`docker build --platform linux/amd64 .` locally against the current tree succeeds, with the smoke test reporting `s3cmd version 2.4.0`. This PR is itself the live test of the trigger.

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)